### PR TITLE
[FIX] Wrong variable use shader -> shaderProgram

### DIFF
--- a/tutorial/sample3/webgl-demo.js
+++ b/tutorial/sample3/webgl-demo.js
@@ -175,7 +175,7 @@ function initShaders() {
   // If creating the shader program failed, alert
 
   if (!gl.getProgramParameter(shaderProgram, gl.LINK_STATUS)) {
-    alert("Unable to initialize the shader program: " + gl.getProgramInfoLog(shader));
+    alert("Unable to initialize the shader program: " + gl.getProgramInfoLog(shaderProgram));
   }
 
   gl.useProgram(shaderProgram);


### PR DESCRIPTION
getProgramInfoLog uses the shader's id but should use the program's id.