### PR TITLE
add experimental-webgl to feature detection

### DIFF
--- a/tutorial/sample5/webgl-demo.js
+++ b/tutorial/sample5/webgl-demo.js
@@ -7,7 +7,7 @@ main();
 //
 function main() {
   const canvas = document.querySelector('#glcanvas');
-  const gl = canvas.getContext('webgl');
+  const gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
 
   // If we don't have a GL context, give up now
 


### PR DESCRIPTION
currently Edge fails the feature detect because webgl is only behind `experimental-webgl`. This fixes that.