### PR TITLE
Fixed attribute types

### DIFF
--- a/tutorial/sample2/webgl-demo.js
+++ b/tutorial/sample2/webgl-demo.js
@@ -17,13 +17,13 @@ function main() {
   // Vertex shader program
 
   const vsSource = `
-    attribute vec4 aVertexPosition;
+    attribute vec2 aVertexPosition;
 
     uniform mat4 uModelViewMatrix;
     uniform mat4 uProjectionMatrix;
 
     void main() {
-      gl_Position = uProjectionMatrix * uModelViewMatrix * aVertexPosition;
+      gl_Position = uProjectionMatrix * uModelViewMatrix * vec4(aVertexPosition, 0.0, 1.0);
     }
   `;
 

--- a/tutorial/sample3/webgl-demo.js
+++ b/tutorial/sample3/webgl-demo.js
@@ -17,7 +17,7 @@ function main() {
   // Vertex shader program
 
   const vsSource = `
-    attribute vec4 aVertexPosition;
+    attribute vec2 aVertexPosition;
     attribute vec4 aVertexColor;
 
     uniform mat4 uModelViewMatrix;
@@ -26,7 +26,7 @@ function main() {
     varying lowp vec4 vColor;
 
     void main(void) {
-      gl_Position = uProjectionMatrix * uModelViewMatrix * aVertexPosition;
+      gl_Position = uProjectionMatrix * uModelViewMatrix * vec4(aVertexPosition, 0.0, 1.0);
       vColor = aVertexColor;
     }
   `;

--- a/tutorial/sample4/webgl-demo.js
+++ b/tutorial/sample4/webgl-demo.js
@@ -19,7 +19,7 @@ function main() {
   // Vertex shader program
 
   const vsSource = `
-    attribute vec4 aVertexPosition;
+    attribute vec2 aVertexPosition;
     attribute vec4 aVertexColor;
 
     uniform mat4 uModelViewMatrix;
@@ -28,7 +28,7 @@ function main() {
     varying lowp vec4 vColor;
 
     void main(void) {
-      gl_Position = uProjectionMatrix * uModelViewMatrix * aVertexPosition;
+      gl_Position = uProjectionMatrix * uModelViewMatrix * vec4(aVertexPosition, 0.0, 1.0);
       vColor = aVertexColor;
     }
   `;

--- a/tutorial/sample5/webgl-demo.js
+++ b/tutorial/sample5/webgl-demo.js
@@ -19,7 +19,7 @@ function main() {
   // Vertex shader program
 
   const vsSource = `
-    attribute vec4 aVertexPosition;
+    attribute vec3 aVertexPosition;
     attribute vec4 aVertexColor;
 
     uniform mat4 uModelViewMatrix;
@@ -28,7 +28,7 @@ function main() {
     varying lowp vec4 vColor;
 
     void main(void) {
-      gl_Position = uProjectionMatrix * uModelViewMatrix * aVertexPosition;
+      gl_Position = uProjectionMatrix * uModelViewMatrix * vec4(aVertexPosition, 1.0);
       vColor = aVertexColor;
     }
   `;

--- a/tutorial/sample6/webgl-demo.js
+++ b/tutorial/sample6/webgl-demo.js
@@ -19,7 +19,7 @@ function main() {
   // Vertex shader program
 
   const vsSource = `
-    attribute vec4 aVertexPosition;
+    attribute vec3 aVertexPosition;
     attribute vec2 aTextureCoord;
 
     uniform mat4 uModelViewMatrix;
@@ -28,7 +28,7 @@ function main() {
     varying highp vec2 vTextureCoord;
 
     void main(void) {
-      gl_Position = uProjectionMatrix * uModelViewMatrix * aVertexPosition;
+      gl_Position = uProjectionMatrix * uModelViewMatrix * vec4(aVertexPosition, 1.0);
       vTextureCoord = aTextureCoord;
     }
   `;

--- a/tutorial/sample7/webgl-demo.js
+++ b/tutorial/sample7/webgl-demo.js
@@ -19,7 +19,7 @@ function main() {
   // Vertex shader program
 
   const vsSource = `
-    attribute vec4 aVertexPosition;
+    attribute vec3 aVertexPosition;
     attribute vec3 aVertexNormal;
     attribute vec2 aTextureCoord;
 
@@ -31,7 +31,7 @@ function main() {
     varying highp vec3 vLighting;
 
     void main(void) {
-      gl_Position = uProjectionMatrix * uModelViewMatrix * aVertexPosition;
+      gl_Position = uProjectionMatrix * uModelViewMatrix * vec4(aVertexPosition, 1.0);
       vTextureCoord = aTextureCoord;
 
       // Apply lighting effect

--- a/tutorial/sample8/webgl-demo.js
+++ b/tutorial/sample8/webgl-demo.js
@@ -21,7 +21,7 @@ function main() {
   // Vertex shader program
 
   const vsSource = `
-    attribute vec4 aVertexPosition;
+    attribute vec3 aVertexPosition;
     attribute vec3 aVertexNormal;
     attribute vec2 aTextureCoord;
 
@@ -33,7 +33,7 @@ function main() {
     varying highp vec3 vLighting;
 
     void main(void) {
-      gl_Position = uProjectionMatrix * uModelViewMatrix * aVertexPosition;
+      gl_Position = uProjectionMatrix * uModelViewMatrix * vec4(aVertexPosition, 1.0);
       vTextureCoord = aTextureCoord;
 
       // Apply lighting effect


### PR DESCRIPTION
I know this follows the OpenGL specification (didn't check WebGL specifically).

However the [tutorial][tutorial] doesn't address why it uses a `vec4`, when later `gl.vertexAttribPointer` is passed `2` and `3`, but never `4`.

This could confuse the reader, I'd suggest changing the type, so it's easier for the reader to associate the connection between `aVertexPosition`'s type and `numComponents`.

[tutorial]: https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/Tutorial/Adding_2D_content_to_a_WebGL_context
