### PR TITLE
fix: update code to match tutorial

### DIFF
--- a/tutorial/sample1/index.html
+++ b/tutorial/sample1/index.html
@@ -1,38 +1,41 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <title>WebGL Demo</title>
-    <meta charset="utf-8">
-    <link rel="stylesheet" href="./webgl.css" type="text/css">
-  </head>
 
-  <body>
-    <canvas id="glcanvas" width="640" height="480"></canvas>
-  </body>
+<head>
+  <title>WebGL Demo</title>
+  <meta charset="utf-8">
+  <link rel="stylesheet" href="./webgl.css" type="text/css">
+</head>
 
-  <script>
-    main();
+<body>
+  <canvas id="glcanvas" width="640" height="480"></canvas>
+</body>
 
-    //
-    // Start here
-    //
-    function main() {
-      const canvas = document.querySelector('#glcanvas');
-      // Initialize the GL context
-      const gl = canvas.getContext('webgl');
+<script>
+  //
+  // Start here
+  //
+  function main() {
+    const canvas = document.querySelector('#glcanvas');
+    // Initialize the GL context
+    const gl = canvas.getContext('webgl');
 
-      // If we don't have a GL context, give up now
-      // Only continue if WebGL is available and working
+    // If we don't have a GL context, give up now
+    // Only continue if WebGL is available and working
 
-      if (!gl) {
-        alert('Unable to initialize WebGL. Your browser or machine may not support it.');
-        return;
-      }
-
-      // Set clear color to black, fully opaque
-      gl.clearColor(0.0, 0.0, 0.0, 1.0);
-      // Clear the color buffer with specified clear color
-      gl.clear(gl.COLOR_BUFFER_BIT);
+    if (!gl) {
+      alert('Unable to initialize WebGL. Your browser or machine may not support it.');
+      return;
     }
-  </script>
+
+    // Set clear color to black, fully opaque
+    gl.clearColor(0.0, 0.0, 0.0, 1.0);
+    // Clear the color buffer with specified clear color
+    gl.clear(gl.COLOR_BUFFER_BIT);
+  }
+
+
+  window.onload = main;
+</script>
+
 </html>


### PR DESCRIPTION
As mentioned in https://github.com/mdn/webgl-examples/issues/26 the tutorial mentions the use of `window.onload = main;` but, the code in the repo does not follow that patter. It instead calls the `main` function on line 1 of the JavaScript block.

This pull request updates the example to match the copy in the tutorial.

fix #26